### PR TITLE
Matching string type of environment variables to utf-8

### DIFF
--- a/tools/roslaunch/src/roslaunch/core.py
+++ b/tools/roslaunch/src/roslaunch/core.py
@@ -204,6 +204,11 @@ def setup_env(node, machine, master_uri, env=None):
         for name, value in node.env_args:
             d[name] = value
 
+    if os.name == 'nt':
+        for i in d:
+            if type(d[i]).__name__ == "unicode":
+                d[i] = d[i].encode('utf-8')
+
     return d
 
 def rle_wrapper(fn):


### PR DESCRIPTION
When subprocess.Popen of pywin32 is called, it throws TypeError if the environment variables contain unicode.

This pull request is to resolve TypeError as converting unicode string to utf-8 when getting the environment variables.
