### PR TITLE
Fix to env variable discovery logic

### DIFF
--- a/tools/roslaunch/env-hooks/10.roslaunch.bat
+++ b/tools/roslaunch/env-hooks/10.roslaunch.bat
@@ -1,5 +1,5 @@
 REM roslaunch/env-hooks/10.roslaunch.bat
 
-if [%ROS_MASTER_URI%]==[] (
+if "%ROS_MASTER_URI%"=="" (
   set ROS_MASTER_URI=http://localhost:11311
 )


### PR DESCRIPTION
The original logic for the batch file works if ROS_MASTER_URI does not exist. However, it would fail if the variable was already in the environment causing windows bail reporting "]==[] was unexpected," and as a consequence would cause the entire ROS environment setup to fail. The updated logic in this patch works whether or not the ROS_MASTER_URI variable exists.

See this original pull request for context: [Win_ros pull request #44](https://github.com/ros-windows/win_ros/pull/44)
